### PR TITLE
Revert "test: remove unused serial_test dev-dependencies"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "ratatui",
  "secrecy",
  "serde",
+ "serial_test",
  "thiserror 2.0.12",
  "toml 0.8.23",
  "totp-rs",
@@ -1526,6 +1527,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1551,12 @@ dependencies = [
  "salsa20",
  "sha2",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "secrecy"
@@ -1599,6 +1615,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ clap_complete = "4.5.54"
 thiserror = "2.0.12"
 arboard = { version = "3.6.0", default-features = false, features = ["wayland-data-control"] }
 
+[dev-dependencies]
+serial_test = "3.2.0"
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/tests/path_test.rs
+++ b/tests/path_test.rs
@@ -5,7 +5,6 @@ use auth::auth_core::app::App;
 use serial_test::serial;
 
 #[test]
-#[serial]
 fn test_home_path_expansion() {
     let home = dirs::home_dir().unwrap();
 
@@ -14,7 +13,6 @@ fn test_home_path_expansion() {
 }
 
 #[test]
-#[serial]
 fn test_env_var_expansion() {
     let test_env = &env::temp_dir().join("test_env");
     unsafe {
@@ -26,7 +24,6 @@ fn test_env_var_expansion() {
 }
 
 #[test]
-#[serial]
 fn test_auth_entries_dir_env_var() {
     let test_auth_dir = &env::temp_dir().join("test_auth_dir");
     unsafe {
@@ -44,7 +41,6 @@ fn test_auth_entries_dir_env_var() {
 }
 
 #[test]
-#[serial]
 fn test_absolute_path() {
     let test_path = if cfg!(windows) {
         r"C:\Windows\System32\drivers\etc\hosts"

--- a/tests/path_test.rs
+++ b/tests/path_test.rs
@@ -2,8 +2,10 @@ use std::env;
 use std::path::PathBuf;
 
 use auth::auth_core::app::App;
+use serial_test::serial;
 
 #[test]
+#[serial]
 fn test_home_path_expansion() {
     let home = dirs::home_dir().unwrap();
 
@@ -12,6 +14,7 @@ fn test_home_path_expansion() {
 }
 
 #[test]
+#[serial]
 fn test_env_var_expansion() {
     let test_env = &env::temp_dir().join("test_env");
     unsafe {
@@ -23,6 +26,7 @@ fn test_env_var_expansion() {
 }
 
 #[test]
+#[serial]
 fn test_auth_entries_dir_env_var() {
     let test_auth_dir = &env::temp_dir().join("test_auth_dir");
     unsafe {
@@ -40,6 +44,7 @@ fn test_auth_entries_dir_env_var() {
 }
 
 #[test]
+#[serial]
 fn test_absolute_path() {
     let test_path = if cfg!(windows) {
         r"C:\Windows\System32\drivers\etc\hosts"
@@ -51,6 +56,7 @@ fn test_absolute_path() {
 }
 
 #[test]
+#[serial]
 fn test_file_browser_dir_env_var() {
     let test_dir = env::temp_dir().join("test_file_browser_dir");
     std::fs::create_dir_all(&test_dir).expect("Failed to create test directory");
@@ -70,6 +76,7 @@ fn test_file_browser_dir_env_var() {
 }
 
 #[test]
+#[serial]
 fn test_file_browser_invalid_dir() {
     let home = dirs::home_dir().unwrap();
     let nonexistent_dir = env::temp_dir().join("nonexistent_dir_123456789");


### PR DESCRIPTION
Reverts xsy420/auth#31

test methods will change  AUTH_FILE_BROWSER_DIR variable in env, so serial_test is still needed.
